### PR TITLE
Don't use innerHTML for compiled output

### DIFF
--- a/components/polymer/dust-demo.html
+++ b/components/polymer/dust-demo.html
@@ -143,7 +143,8 @@
             console.log('render error');
           }
 
-          compiledBox.innerHTML = compiledDust;
+          compiledBox.innerHTML = '';
+          compiledBox.appendChild(document.createTextNode(compiledDust));
           outputBox.innerHTML = dust.escapeHtml(out);
         })
       },


### PR DESCRIPTION
Escape the text by using `document.createTextNode`. Fixes #19
